### PR TITLE
Fix audio cleanup timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,9 +368,9 @@ SRC_DIR = src
 OBJ_DIR = obj
 
 # Define all object files from source files
-SRC = $(call rwildcard, *.c, *.h)
-#OBJS = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
-OBJS ?= main.c
+SRC = $(call rwildcard, *.c, *.h, *.cpp, *.hpp)
+#OBJS = $(SRC:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
+OBJS ?= $(SRC_DIR)/main.cpp
 
 # For Android platform we call a custom Makefile.Android
 ifeq ($(PLATFORM),PLATFORM_ANDROID)
@@ -392,8 +392,8 @@ $(PROJECT_NAME): $(OBJS)
 
 # Compile source files
 # NOTE: This pattern will compile every module defined on $(OBJS)
-#%.o: %.c
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+#%.o: %.cpp
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
 	$(CC) -c $< -o $@ $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
 
 # Clean everything

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -517,15 +517,18 @@ int main() {
     // Initialize the audio system for playing sounds
     InitAudioDevice();
 
-    // Create instances of the GameMenu and Game classes
-    GameMenu menu;
-    Game game;
+    // Wrap game objects in a scope so that they are destroyed
+    // before the audio device is closed at the end of main
+    {
+        // Create instances of the GameMenu and Game classes
+        GameMenu menu;
+        Game game;
 
-    // Pass the address of 'menu' to 'game' so it can interact with the menu
-    game.SetMenu(&menu);
+        // Pass the address of 'menu' to 'game' so it can interact with the menu
+        game.SetMenu(&menu);
 
-    // Main game loop - continues until the window close event is triggered
-    while (!WindowShouldClose()) {
+        // Main game loop - continues until the window close event is triggered
+        while (!WindowShouldClose()) {
         // Start drawing graphics
         BeginDrawing();
 
@@ -584,8 +587,9 @@ int main() {
         // End the drawing process
         EndDrawing();
     }
-
-    // Cleanup resources before closing
+    // Objects 'menu' and 'game' are destroyed here
+    
+    // Cleanup resources after objects have released their audio data
     CloseAudioDevice();
     CloseWindow();
     return 0;


### PR DESCRIPTION
## Summary
- ensure `Game` and `Food` destructors run before closing the audio device
- fix Makefile so C++ sources build correctly

## Testing
- `make` *(fails: fatal error: raylib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68675183522083258da7ece2b33b625b